### PR TITLE
Fix code scanning alert no. 3: Insecure randomness

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,19 +5,29 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    assignees:
+      - solairen
   - package-ecosystem: nuget
     directory: "/src"
     schedule:
       interval: monthly
+    assignees:
+      - solairen
   - package-ecosystem: nuget
     directory: "/test"
     schedule:
       interval: monthly
+    assignees:
+      - solairen
   - package-ecosystem: devcontainers
     directory: "/.devcontainer"
     schedule:
       interval: monthly
-- package-ecosystem: dotnet-sdk
-  directory: "/src"
-  schedule:
-    interval: "monthly"
+    assignees:
+      - solairen
+  - package-ecosystem: dotnet-sdk
+    directory: "/src"
+    schedule:
+      interval: "monthly"
+    assignees:
+        - solairen

--- a/test/UnitTest1.cs
+++ b/test/UnitTest1.cs
@@ -2,6 +2,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Linq;
 using System.Security.Cryptography;
+
 namespace Test
 {
   [TestClass]
@@ -9,23 +10,24 @@ namespace Test
   {
     private const string Characters = "AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz0123456789";
     private const string SpecialCharacters = "!@#$%^&*";
-    private readonly RNGCryptoServiceProvider rng = new RNGCryptoServiceProvider();
+    private readonly RandomNumberGenerator rng = RandomNumberGenerator.Create();
 
-    [TestMethod]
-    public void GeneratePassword_Length99_ReturnsPasswordWithLength99()
+    [DataTestMethod]
+    [DataRow(99, false)]
+    [DataRow(6, true)]
+    public void GeneratePassword_Test(int length, bool includeSpecialChar)
     {
-      int length = 99;
-      string password = GeneratePassword(length, includeSpecialChar: false);
+      string password = GeneratePassword(length, includeSpecialChar);
       Assert.AreEqual(length, password.Length);
-    }
 
-    [TestMethod]
-    public void GeneratePassword_Length6WithSpecialChar_ReturnsPasswordWithLength6AndSpecialChar()
-    {
-      int length = 6;
-      string password = GeneratePassword(length, includeSpecialChar: true);
-      Assert.AreEqual(length, password.Length);
-      Assert.IsTrue(password.Any(c => SpecialCharacters.Contains(c)));
+      if (includeSpecialChar)
+      {
+        Assert.IsTrue(password.Any(c => SpecialCharacters.Contains(c)), "Password does not contain any special characters.");
+      }
+      else
+      {
+        Assert.IsFalse(password.Any(c => SpecialCharacters.Contains(c)), "Password contains special characters.");
+      }
     }
 
     private string GeneratePassword(int length, bool includeSpecialChar)

--- a/test/UnitTest1.cs
+++ b/test/UnitTest1.cs
@@ -1,7 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Linq;
-
+using System.Security.Cryptography;
 namespace Test
 {
   [TestClass]
@@ -9,7 +9,7 @@ namespace Test
   {
     private const string Characters = "AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz0123456789";
     private const string SpecialCharacters = "!@#$%^&*";
-    private readonly Random random = new Random();
+    private readonly RNGCryptoServiceProvider rng = new RNGCryptoServiceProvider();
 
     [TestMethod]
     public void GeneratePassword_Length99_ReturnsPasswordWithLength99()
@@ -37,8 +37,9 @@ namespace Test
         availableCharacters += SpecialCharacters;
       }
 
-      string password = new string(Enumerable.Repeat(availableCharacters, length)
-          .Select(s => s[random.Next(s.Length)]).ToArray());
+      byte[] randomBytes = new byte[length];
+      rng.GetBytes(randomBytes);
+      string password = new string(randomBytes.Select(b => availableCharacters[b % availableCharacters.Length]).ToArray());
 
       return password;
     }


### PR DESCRIPTION
Fixed #60 

Fixes [https://github.com/solairen/password_generator/security/code-scanning/3](https://github.com/solairen/password_generator/security/code-scanning/3)

To fix the problem, we need to replace the use of the `Random` class with a cryptographically secure random number generator. In C#, the `RNGCryptoServiceProvider` class provides a cryptographically secure random number generator. We will modify the `GeneratePassword` method to use `RNGCryptoServiceProvider` instead of `Random`.

- Replace the `Random` instance with an instance of `RNGCryptoServiceProvider`.
- Modify the code to generate random bytes and convert them to indices for selecting characters from the available characters string.
- Ensure that the functionality of generating a password of a specified length, with or without special characters, remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
